### PR TITLE
Bundle commit ref into binary for (Sentry) version tracking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,3 +19,4 @@ jobs:
           tag_with_ref: true
           tag_with_sha: true
           add_git_labels: true
+          build_args: version=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN GO111MODULE=on go mod download
 # Copy source code
 COPY ./server $GOPATH/server/
 
-# bundle version into binary if specified in build-args if specified, dev otherwise.
+# bundle version into binary if specified in build-args, dev otherwise.
 ARG version=dev
 # Compile statically
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-w -extldflags '-static' -X main.Version=${version}" -o /backend main.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ RUN GO111MODULE=on go mod download
 # Copy source code
 COPY ./server $GOPATH/server/
 
+# bundle version into binary if specified in build-args if specified, dev otherwise.
+ARG version=dev
 # Compile statically
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-w -extldflags "-static"' -o /backend main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-w -extldflags '-static' -X main.Version=${version}" -o /backend main.go
 RUN chmod +x /backend
 
 FROM scratch

--- a/server/main.go
+++ b/server/main.go
@@ -19,6 +19,7 @@ const (
 	httpPort = ":50051"
 	grpcPort = ":50052"
 )
+
 var Version = "dev"
 
 func main() {
@@ -32,10 +33,16 @@ func main() {
 		conn = sqlite.Open("test.db")
 		shouldAutoMigrate = true
 	}
+
+	environment := "development"
+	if Version != "dev" {
+		environment = "production"
+	}
 	if sentryDSN := os.Getenv("SENTRY_DSN"); sentryDSN != "" {
 		if err := sentry.Init(sentry.ClientOptions{
-			Dsn: os.Getenv("SENTRY_DSN"),
-			Release: Version,
+			Dsn:         os.Getenv("SENTRY_DSN"),
+			Release:     Version,
+			Environment: environment,
 		}); err != nil {
 			log.Printf("Sentry initialization failed: %v\n", err)
 		}

--- a/server/main.go
+++ b/server/main.go
@@ -19,6 +19,7 @@ const (
 	httpPort = ":50051"
 	grpcPort = ":50052"
 )
+var Version = "dev"
 
 func main() {
 	// Connect to DB
@@ -34,6 +35,7 @@ func main() {
 	if sentryDSN := os.Getenv("SENTRY_DSN"); sentryDSN != "" {
 		if err := sentry.Init(sentry.ClientOptions{
 			Dsn: os.Getenv("SENTRY_DSN"),
+			Release: Version,
 		}); err != nil {
 			log.Printf("Sentry initialization failed: %v\n", err)
 		}


### PR DESCRIPTION
Just wanted to mark sentry issue 2411515386 as resolved in the next release which obviously doesn't work if sentry doesn't know the version.