### PR TITLE
deploy PRs to testserver

### DIFF
--- a/.github/workflows/testserver.yml
+++ b/.github/workflows/testserver.yml
@@ -42,3 +42,7 @@ jobs:
           build-args: version=${{ steps.vars.outputs.sha_short }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: remove label
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: testserver

--- a/.github/workflows/testserver.yml
+++ b/.github/workflows/testserver.yml
@@ -1,0 +1,44 @@
+name: Deploy to Test Server
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  build:
+    if: ${{ github.event.label.name == 'testserver' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set outputs
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/tum-dev/campus-backend/test-backend
+          tags: |
+            type=sha
+          flavor: |
+            latest=true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          pull: true
+          push: true
+          build-args: version=${{ steps.vars.outputs.sha_short }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
We should use the spare rbg server as a test instance to deploy PRs to. 

This pr adds an action to push another image to githubs container registry that can be checked out by the testserver. This action is triggered when the label 'testserver' is added.

The testserver is deployed at backend.tca.uwpx.org and grpc.backend.tca.uwpx.org respectively. We could need other domains (e.g. test.api.tum.app or staging.api.tum.app?)