### PR TITLE
Parameter to Deactivate Cafeteria Cronjobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,9 @@ This repository holds the following components:
 The API is publicly available for use by anyone, but most notably its the main backend system for the
 TUM Campus Apps (Android, iOS and Windows).
 
+### Running the Backend
+Optional Commandline Parameter: `-MensaCron 0` deactivates the Mensa Rating cronjobs if not needed in a local setup. The Cronjobs are activated if the parameter is not explicitly added.
+
+
+
 Please be respectful with its usage!

--- a/server/backend/cron/cronjobs.go
+++ b/server/backend/cron/cronjobs.go
@@ -72,11 +72,11 @@ func (c *CronService) Run() error {
 				g.Go(func() error { return c.fileDownloadCron() })
 			case DISH_NAME_DOWNLOAD:
 				if c.useMensa {
-					g.Go(func() error { return c.dishNameDownloadCron() })
+					g.Go(c.dishNameDownloadCron)
 				}
 			case AVERAGE_RATING_COMPUTATION: //call every five minutes between 11AM and 4 PM on weekdays
 				if c.useMensa {
-					g.Go(func() error { return c.averageRatingComputation() })
+					g.Go(c.averageRatingComputation)
 				}
 				/*
 					TODO: Implement handlers for other cronjobs

--- a/server/main.go
+++ b/server/main.go
@@ -79,8 +79,13 @@ func main() {
 		return
 	}
 
+	var mensaCronActivated = true
+	if len(os.Args) > 2 && os.Args[1] == "-MensaCron" && os.Args[2] == "0" {
+		mensaCronActivated = false
+		log.Println("Cronjobs for the cafeteria rating are deactivated. Remove commandline argument <-MensaCron 0> or set it to 1.", len(os.Args))
+	}
 	// Create any other background services (these shouldn't do any long running work here)
-	cronService := cron.New(db)
+	cronService := cron.New(db, mensaCronActivated)
 	campusService := backend.New(db)
 
 	// Listen to our configured ports


### PR DESCRIPTION
Parameter `-MensaCron 0` can be used to deactivate the cronjobs for the cafeteria rating in order to simplify a test setup. If the parameter is not added, the cronjobs will be activated by default.