### PR TITLE
MySQL VARCHAR missing length fix

### DIFF
--- a/server/backend/migration/20220126230000.go
+++ b/server/backend/migration/20220126230000.go
@@ -5,8 +5,8 @@ import (
 	"gorm.io/gorm"
 )
 
-//migrate20220126230000
-//adds a fulltext index to the roomfinder_rooms table
+// migrate20220126230000
+// adds a fulltext index to the roomfinder_rooms table
 func (m TumDBMigrator) migrate20220126230000() *gormigrate.Migration {
 	return &gormigrate.Migration{
 		ID: "20220126230000",

--- a/server/backend/migration/migration.go
+++ b/server/backend/migration/migration.go
@@ -1,4 +1,4 @@
-//Package migration contains functions related to database changes and executes them
+// Package migration contains functions related to database changes and executes them
 package migration
 
 import (
@@ -8,18 +8,18 @@ import (
 	"gorm.io/gorm"
 )
 
-//TumDBMigrator contains a reference to our database
+// TumDBMigrator contains a reference to our database
 type TumDBMigrator struct {
 	database          *gorm.DB
 	shouldAutoMigrate bool
 }
 
-//New creates a new TumDBMigrator with a database
+// New creates a new TumDBMigrator with a database
 func New(db *gorm.DB, shouldAutoMigrate bool) TumDBMigrator {
 	return TumDBMigrator{database: db, shouldAutoMigrate: shouldAutoMigrate}
 }
 
-//Migrate starts the migration either by using AutoMigrate in development environments or manually in prod
+// Migrate starts the migration either by using AutoMigrate in development environments or manually in prod
 func (m TumDBMigrator) Migrate() error {
 	if m.shouldAutoMigrate {
 		log.Info("Using automigration")

--- a/server/model/devices.go
+++ b/server/model/devices.go
@@ -13,7 +13,7 @@ type Devices struct {
 	//[ 1] member                                         int                  null: true   primary: false  isArray: false  auto: false  col: int             len: -1      default: []
 	Member null.Int `gorm:"column:member;type:int;" json:"member"`
 	//[ 2] uuid                                           varchar(50)          null: false  primary: false  isArray: false  auto: false  col: varchar         len: 50      default: []
-	UUID string `gorm:"column:uuid;type:varchar;size:50;" json:"uuid"`
+	UUID string `gorm:"column:uuid;type:varchar(50);" json:"uuid"`
 	//[ 3] created                                        timestamp            null: true   primary: false  isArray: false  auto: false  col: timestamp       len: -1      default: []
 	Created null.Time `gorm:"column:created;type:timestamp;" json:"created"`
 	//[ 4] lastAccess                                     timestamp            null: false  primary: false  isArray: false  auto: false  col: timestamp       len: -1      default: [0000-00-00 00:00:00]
@@ -35,9 +35,9 @@ type Devices struct {
 	//[12] gcmToken                                       text(65535)          null: true   primary: false  isArray: false  auto: false  col: text            len: 65535   default: []
 	GcmToken null.String `gorm:"column:gcmToken;type:text;size:65535;" json:"gcm_token"`
 	//[13] gcmStatus                                      varchar(200)         null: true   primary: false  isArray: false  auto: false  col: varchar         len: 200     default: []
-	GcmStatus null.String `gorm:"column:gcmStatus;type:varchar;size:200;" json:"gcm_status"`
+	GcmStatus null.String `gorm:"column:gcmStatus;type:varchar(200);" json:"gcm_status"`
 	//[14] confirmationKey                                varchar(35)          null: true   primary: false  isArray: false  auto: false  col: varchar         len: 35      default: []
-	ConfirmationKey null.String `gorm:"column:confirmationKey;type:varchar;size:35;" json:"confirmation_key"`
+	ConfirmationKey null.String `gorm:"column:confirmationKey;type:varchar(35);" json:"confirmation_key"`
 	//[15] keyCreated                                     datetime             null: true   primary: false  isArray: false  auto: false  col: datetime        len: -1      default: []
 	KeyCreated null.Time `gorm:"column:keyCreated;type:datetime;" json:"key_created"`
 	//[16] keyConfirmed                                   datetime             null: true   primary: false  isArray: false  auto: false  col: datetime        len: -1      default: []

--- a/server/model/news.go
+++ b/server/model/news.go
@@ -28,7 +28,7 @@ type News struct {
 	//[ 5] src                                            int                  null: false  primary: false  isArray: false  auto: false  col: int             len: -1      default: []
 	Src int32 `gorm:"column:src;type:int;" json:"src"`
 	//[ 6] link                                           varchar(190)         null: false  primary: false  isArray: false  auto: false  col: varchar         len: 190     default: []
-	Link string `gorm:"column:link;type:varchar;size:190;" json:"link"`
+	Link string `gorm:"column:link;type:varchar(190);" json:"link"`
 	//[ 7] image                                          text(65535)          null: true   primary: false  isArray: false  auto: false  col: text            len: 65535   default: []
 	Image null.String `gorm:"column:image;type:text;size:65535;" json:"image"`
 	//[ 8] file                                           int                  null: true   primary: false  isArray: false  auto: false  col: int             len: -1      default: []
@@ -39,4 +39,3 @@ type News struct {
 func (n *News) TableName() string {
 	return "news"
 }
-

--- a/server/model/news_alert.go
+++ b/server/model/news_alert.go
@@ -22,7 +22,7 @@ type NewsAlert struct {
 	//[ 1] file                                           int                  null: true   primary: false  isArray: false  auto: false  col: int             len: -1      default: []
 	File null.Int `gorm:"column:file;type:int;" json:"file"`
 	//[ 2] name                                           varchar(100)         null: true   primary: false  isArray: false  auto: false  col: varchar         len: 100     default: []
-	Name null.String `gorm:"column:name;type:varchar;size:100;" json:"name"`
+	Name null.String `gorm:"column:name;type:varchar(100);" json:"name"`
 	//[ 3] link                                           text(65535)          null: true   primary: false  isArray: false  auto: false  col: text            len: 65535   default: []
 	Link null.String `gorm:"column:link;type:text;size:65535;" json:"link"`
 	//[ 4] created                                        timestamp            null: false  primary: false  isArray: false  auto: false  col: timestamp       len: -1      default: [CURRENT_TIMESTAMP]
@@ -32,7 +32,6 @@ type NewsAlert struct {
 	//[ 6] to                                             datetime             null: false  primary: false  isArray: false  auto: false  col: datetime        len: -1      default: [CURRENT_TIMESTAMP]
 	To time.Time `gorm:"column:to;type:datetime;default:CURRENT_TIMESTAMP;" json:"to"`
 }
-
 
 // TableName sets the insert table name for this struct type
 func (n *NewsAlert) TableName() string {


### PR DESCRIPTION
`VARCHAR` in MariaDB needs a length specifier. Docs:  https://mariadb.com/kb/en/varchar/
The old way of declaring the size for a `VARCHAR` does not properly propagate to mysql (MariaDB).
GORM docs: https://kenanbek.github.io/go-gorm-varchar-size

Also Formatted the comments inside the migrations.