### PR TITLE
Roomfinder DB Auto migration/creation Fix

### DIFF
--- a/server/backend/migration/20220126230000.go
+++ b/server/backend/migration/20220126230000.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"github.com/TUM-Dev/Campus-Backend/model"
 	"github.com/go-gormigrate/gormigrate/v2"
 	"gorm.io/gorm"
 )
@@ -11,6 +12,12 @@ func (m TumDBMigrator) migrate20220126230000() *gormigrate.Migration {
 	return &gormigrate.Migration{
 		ID: "20220126230000",
 		Migrate: func(tx *gorm.DB) error {
+			if err := tx.AutoMigrate(
+				&model.RoomfinderRooms{},
+			); err != nil {
+				return err
+			}
+
 			return tx.Exec("CREATE FULLTEXT INDEX `search_index` ON `roomfinder_rooms` (`info`, `address`, `room_code`)").Error
 		},
 		Rollback: func(tx *gorm.DB) error {

--- a/server/backend/migration/20220126230000.go
+++ b/server/backend/migration/20220126230000.go
@@ -6,14 +6,19 @@ import (
 	"gorm.io/gorm"
 )
 
-//migrate20220126230000
-//adds a fulltext index to the roomfinder_rooms table
+// migrate20220126230000
+// adds a fulltext index to the roomfinder_rooms table
 func (m TumDBMigrator) migrate20220126230000() *gormigrate.Migration {
 	return &gormigrate.Migration{
 		ID: "20220126230000",
 		Migrate: func(tx *gorm.DB) error {
 			if err := tx.AutoMigrate(
 				&model.RoomfinderRooms{},
+				&model.RoomfinderBuilding2area{},
+				&model.RoomfinderBuildings2gps{},
+				&model.RoomfinderBuildings2maps{},
+				&model.RoomfinderRooms{},
+				&model.RoomfinderRooms2maps{},
 			); err != nil {
 				return err
 			}

--- a/server/model/roomfinder_building2area.go
+++ b/server/model/roomfinder_building2area.go
@@ -20,11 +20,11 @@ type RoomfinderBuilding2area struct {
 	//[ 0] area_id                                        int                  null: false  primary: false  isArray: false  auto: false  col: int             len: -1      default: []
 	AreaID int32 `gorm:"column:area_id;type:int;" json:"area_id"`
 	//[ 1] building_nr                                    varchar(8)           null: false  primary: true   isArray: false  auto: false  col: varchar         len: 8       default: []
-	BuildingNr string `gorm:"primary_key;column:building_nr;type:varchar;size:8;" json:"building_nr"`
+	BuildingNr string `gorm:"primary_key;column:building_nr;type:varchar(8);" json:"building_nr"`
 	//[ 2] campus                                         char(1)              null: false  primary: false  isArray: false  auto: false  col: char            len: 1       default: []
 	Campus string `gorm:"column:campus;type:char;size:1;" json:"campus"`
 	//[ 3] name                                           varchar(32)          null: false  primary: false  isArray: false  auto: false  col: varchar         len: 32      default: []
-	Name string `gorm:"column:name;type:varchar;size:32;" json:"name"`
+	Name string `gorm:"column:name;type:varchar(32);" json:"name"`
 }
 
 // TableName sets the insert table name for this struct type

--- a/server/model/roomfinder_buildings.go
+++ b/server/model/roomfinder_buildings.go
@@ -18,13 +18,13 @@ var (
 // RoomfinderBuildings struct is a row record of the roomfinder_buildings table in the tca database
 type RoomfinderBuildings struct {
 	//[ 0] building_nr                                    varchar(8)           null: false  primary: true   isArray: false  auto: false  col: varchar         len: 8       default: []
-	BuildingNr string `gorm:"primary_key;column:building_nr;type:varchar;size:8;" json:"building_nr"`
+	BuildingNr string `gorm:"primary_key;column:building_nr;type:varchar(8);" json:"building_nr"`
 	//[ 1] utm_zone                                       varchar(4)           null: true   primary: false  isArray: false  auto: false  col: varchar         len: 4       default: []
-	UtmZone null.String `gorm:"column:utm_zone;type:varchar;size:4;" json:"utm_zone"`
+	UtmZone null.String `gorm:"column:utm_zone;type:varchar(4);" json:"utm_zone"`
 	//[ 2] utm_easting                                    varchar(32)          null: true   primary: false  isArray: false  auto: false  col: varchar         len: 32      default: []
-	UtmEasting null.String `gorm:"column:utm_easting;type:varchar;size:32;" json:"utm_easting"`
+	UtmEasting null.String `gorm:"column:utm_easting;type:varchar(32);" json:"utm_easting"`
 	//[ 3] utm_northing                                   varchar(32)          null: true   primary: false  isArray: false  auto: false  col: varchar         len: 32      default: []
-	UtmNorthing null.String `gorm:"column:utm_northing;type:varchar;size:32;" json:"utm_northing"`
+	UtmNorthing null.String `gorm:"column:utm_northing;type:varchar(32);" json:"utm_northing"`
 	//[ 4] default_map_id                                 int                  null: true   primary: false  isArray: false  auto: false  col: int             len: -1      default: []
 	DefaultMapID null.Int `gorm:"column:default_map_id;type:int;" json:"default_map_id"`
 }

--- a/server/model/roomfinder_buildings2gps.go
+++ b/server/model/roomfinder_buildings2gps.go
@@ -18,11 +18,11 @@ var (
 // RoomfinderBuildings2gps struct is a row record of the roomfinder_buildings2gps table in the tca database
 type RoomfinderBuildings2gps struct {
 	//[ 0] id                                             varchar(8)           null: false  primary: true   isArray: false  auto: false  col: varchar         len: 8       default: []
-	ID string `gorm:"primary_key;column:id;type:varchar;size:8;" json:"id"`
+	ID string `gorm:"primary_key;column:id;type:varchar(8);" json:"id"`
 	//[ 1] latitude                                       varchar(30)          null: true   primary: false  isArray: false  auto: false  col: varchar         len: 30      default: []
-	Latitude null.String `gorm:"column:latitude;type:varchar;size:30;" json:"latitude"`
+	Latitude null.String `gorm:"column:latitude;type:varchar(30);" json:"latitude"`
 	//[ 2] longitude                                      varchar(30)          null: true   primary: false  isArray: false  auto: false  col: varchar         len: 30      default: []
-	Longitude null.String `gorm:"column:longitude;type:varchar;size:30;" json:"longitude"`
+	Longitude null.String `gorm:"column:longitude;type:varchar(30);" json:"longitude"`
 }
 
 // TableName sets the insert table name for this struct type

--- a/server/model/roomfinder_buildings2maps.go
+++ b/server/model/roomfinder_buildings2maps.go
@@ -18,7 +18,7 @@ var (
 // RoomfinderBuildings2maps struct is a row record of the roomfinder_buildings2maps table in the tca database
 type RoomfinderBuildings2maps struct {
 	//[ 0] building_nr                                    varchar(8)           null: false  primary: true   isArray: false  auto: false  col: varchar         len: 8       default: []
-	BuildingNr string `gorm:"primary_key;column:building_nr;type:varchar;size:8;" json:"building_nr"`
+	BuildingNr string `gorm:"primary_key;column:building_nr;type:varchar(8);" json:"building_nr"`
 	//[ 1] map_id                                         int                  null: false  primary: true   isArray: false  auto: false  col: int             len: -1      default: []
 	MapID int32 `gorm:"primary_key;column:map_id;type:int;" json:"map_id"`
 }

--- a/server/model/roomfinder_maps.go
+++ b/server/model/roomfinder_maps.go
@@ -20,7 +20,7 @@ type RoomfinderMaps struct {
 	//[ 0] map_id                                         int                  null: false  primary: true   isArray: false  auto: false  col: int             len: -1      default: []
 	MapID int32 `gorm:"primary_key;column:map_id;type:int;" json:"map_id"`
 	//[ 1] description                                    varchar(64)          null: false  primary: false  isArray: false  auto: false  col: varchar         len: 64      default: []
-	Description string `gorm:"column:description;type:varchar;size:64;" json:"description"`
+	Description string `gorm:"column:description;type:varchar(64);" json:"description"`
 	//[ 2] scale                                          int                  null: false  primary: false  isArray: false  auto: false  col: int             len: -1      default: []
 	Scale int32 `gorm:"column:scale;type:int;" json:"scale"`
 	//[ 3] width                                          int                  null: false  primary: false  isArray: false  auto: false  col: int             len: -1      default: []

--- a/server/model/roomfinder_rooms.go
+++ b/server/model/roomfinder_rooms.go
@@ -20,27 +20,27 @@ type RoomfinderRooms struct {
 	//[ 0] room_id                                        int                  null: false  primary: true   isArray: false  auto: false  col: int             len: -1      default: []
 	RoomID int32 `gorm:"primary_key;column:room_id;type:int;" json:"room_id"`
 	//[ 1] room_code                                      varchar(32)          null: true   primary: false  isArray: false  auto: false  col: varchar         len: 32      default: []
-	RoomCode null.String `gorm:"column:room_code;type:varchar;size:32;" json:"room_code"`
+	RoomCode null.String `gorm:"column:room_code;type:varchar(32);" json:"room_code"`
 	//[ 2] building_nr                                    varchar(8)           null: true   primary: false  isArray: false  auto: false  col: varchar         len: 8       default: []
-	BuildingNr null.String `gorm:"column:building_nr;type:varchar;size:8;" json:"building_nr"`
+	BuildingNr null.String `gorm:"column:building_nr;type:varchar(8);" json:"building_nr"`
 	//[ 3] arch_id                                        varchar(16)          null: true   primary: false  isArray: false  auto: false  col: varchar         len: 16      default: []
-	ArchID null.String `gorm:"column:arch_id;type:varchar;size:16;" json:"arch_id"`
+	ArchID null.String `gorm:"column:arch_id;type:varchar(16);" json:"arch_id"`
 	//[ 4] info                                           varchar(64)          null: true   primary: false  isArray: false  auto: false  col: varchar         len: 64      default: []
-	Info null.String `gorm:"column:info;type:varchar;size:64;" json:"info"`
+	Info null.String `gorm:"column:info;type:varchar(64);" json:"info"`
 	//[ 5] address                                        varchar(128)         null: true   primary: false  isArray: false  auto: false  col: varchar         len: 128     default: []
-	Address null.String `gorm:"column:address;type:varchar;size:128;" json:"address"`
+	Address null.String `gorm:"column:address;type:varchar(128);" json:"address"`
 	//[ 6] purpose_id                                     int                  null: true   primary: false  isArray: false  auto: false  col: int             len: -1      default: []
 	PurposeID null.Int `gorm:"column:purpose_id;type:int;" json:"purpose_id"`
 	//[ 7] purpose                                        varchar(64)          null: true   primary: false  isArray: false  auto: false  col: varchar         len: 64      default: []
-	Purpose null.String `gorm:"column:purpose;type:varchar;size:64;" json:"purpose"`
+	Purpose null.String `gorm:"column:purpose;type:varchar(64);" json:"purpose"`
 	//[ 8] seats                                          int                  null: true   primary: false  isArray: false  auto: false  col: int             len: -1      default: []
 	Seats null.Int `gorm:"column:seats;type:int;" json:"seats"`
 	//[ 9] utm_zone                                       varchar(4)           null: true   primary: false  isArray: false  auto: false  col: varchar         len: 4       default: []
-	UtmZone null.String `gorm:"column:utm_zone;type:varchar;size:4;" json:"utm_zone"`
+	UtmZone null.String `gorm:"column:utm_zone;type:varchar(4);" json:"utm_zone"`
 	//[10] utm_easting                                    varchar(32)          null: true   primary: false  isArray: false  auto: false  col: varchar         len: 32      default: []
-	UtmEasting null.String `gorm:"column:utm_easting;type:varchar;size:32;" json:"utm_easting"`
+	UtmEasting null.String `gorm:"column:utm_easting;type:varchar(32);" json:"utm_easting"`
 	//[11] utm_northing                                   varchar(32)          null: true   primary: false  isArray: false  auto: false  col: varchar         len: 32      default: []
-	UtmNorthing null.String `gorm:"column:utm_northing;type:varchar;size:32;" json:"utm_northing"`
+	UtmNorthing null.String `gorm:"column:utm_northing;type:varchar(32);" json:"utm_northing"`
 	//[12] unit_id                                        int                  null: true   primary: false  isArray: false  auto: false  col: int             len: -1      default: []
 	UnitID null.Int `gorm:"column:unit_id;type:int;" json:"unit_id"`
 	//[13] default_map_id                                 int                  null: true   primary: false  isArray: false  auto: false  col: int             len: -1      default: []


### PR DESCRIPTION
Added a missing auto migration for the `RoomfinderRooms` table.

Fixes the `VARCHAR` detailed here for all roomfinder tables detailed here: #118 