### PR TITLE
Remove SQLite and add MySQL Setup Instructions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,10 +10,9 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}/server/main.go",
-            "args": [
-                "-MensaCron",
-                "0"
-            ]
+            "env": {
+                "DB_DSN": "gorm:GORM_USER_PASSWORD@tcp(localhost:3306)/campus_backend"
+            }
         },
         {
             "name": "Launch Local Server Client",

--- a/README.md
+++ b/README.md
@@ -2,16 +2,78 @@
 
 This repository holds the following components:
 * `api` - the proto API definition in the `CampusService.proto`.
-* `client` - example clients on how to connect to the backend.
+* `client` - example client for how to connect to the backend.
 * `server` - the actual server implementation serving both REST at [api.tum.app](https://api.tum.app)
-   and gRPC endpoints at at [api-grpc.tum.app](https://api-grpc.tum.app).
+   and gRPC endpoints at [api-grpc.tum.app](https://api-grpc.tum.app).
 
-The API is publicly available for use by anyone, but most notably its the main backend system for the
-TUM Campus Apps (Android, iOS and Windows).
+The API is publicly available for anyone, but most notably, it's the main backend system for the TUM Campus Apps (Android, iOS, and Windows).
 
-### Running the Backend
-Optional Commandline Parameter: `-MensaCron 0` deactivates the Mensa Rating cronjobs if not needed in a local setup. The Cronjobs are activated if the parameter is not explicitly added.
+## Running the Server
 
+### Installing Requirements
+
+The backend uses MySQL as its backend for storing data.
+In the following, we provide instructions for installing [MariaDB](https://mariadb.org/) as the DB server of choice.
+
+#### Fedora
+
+```bash
+sudo dnf install mariadb-server
+
+# Enable and start the systemd service
+sudo systemctl enable mariadb
+sudo systemctl start mariadb
+```
+
+More details are available here: https://docs.fedoraproject.org/en-US/quick-docs/installing-mysql-mariadb/
+
+#### Debian/Ubuntu
+
+```bash
+sudo apt install mariadb-server
+
+# Enable and start the systemd service
+sudo systemctl enable mariadb
+sudo systemctl start mariadb
+```
+
+### Setting up the DB
+
+To setup the DB, connect to your DB server or use `mysql` to connect to it locally.
+
+```sql
+DROP DATABASE campus_backend; -- Drop an eventually existing old DB
+CREATE DATABASE campus_backend; -- Create a new DB for the backend
+
+CREATE USER 'gorm'@'localhost' IDENTIFIED BY 'gorm'; -- Create a new user called `gorm`.
+GRANT ALL PRIVILEGES ON campus_backend.* TO 'gorm'@'localhost'; -- Garant our `gorm` user access to the `campus_backend` DB.
+```
+
+### Starting
+
+To start the server there are environment variables, as well as command line options available for configuring the server behavior.
+
+```bash
+cd  server
+export DB_DSN="Your gorm DB connection string for example: gorm@tcp(localhost:3306)/campus_backend"
+go run ./main.go [-MensaCron 0]
+```
+
+#### Environment Variables
+
+There are a few environment variables available:
+
+* [REQUIRED] `DB_DSN`: The [GORM](https://gorm.io/) [DB connection string](https://gorm.io/docs/connecting_to_the_database.html#MySQL) for connecting to the MySQL DB. Example: `gorm@tcp(localhost:3306)/campus_backend`
+* [OPTIONAL] `SENTRY_DSN`: The Sentry [Data Source Name](https://sentry-docs-git-patch-1.sentry.dev/product/sentry-basics/dsn-explainer/) for reporting issues and crashes.
+
+#### Command Line Arguments
+
+* [OPTIONAL] `-MensaCron 0`: Providing this argument deactivates the Mensa Rating cronjobs if not needed in a local setup. Be aware, this option will change in a future version ([#117](https://github.com/TUM-Dev/Campus-Backend/issues/117) and [#115](https://github.com/TUM-Dev/Campus-Backend/issues/115)).
+
+### Visual Studio Code
+
+There are already predefined Visual Studio Code launch tasks for debugging the client and server.
+Take a look at the [`lauch.json`](.vscode/launch.json) file for more details.
 
 
 Please be respectful with its usage!

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ In the following, we provide instructions for installing [MariaDB](https://maria
 ```bash
 sudo dnf install mariadb-server
 
-# Enable and start the systemd service
-sudo systemctl enable mariadb
+# Start the MariaDB server
 sudo systemctl start mariadb
+
+# Optional: Enable autostart
+sudo systemctl enable mariadb
 ```
 
 More details are available here: https://docs.fedoraproject.org/en-US/quick-docs/installing-mysql-mariadb/
@@ -32,9 +34,11 @@ More details are available here: https://docs.fedoraproject.org/en-US/quick-docs
 ```bash
 sudo apt install mariadb-server
 
-# Enable and start the systemd service
-sudo systemctl enable mariadb
+# Start the MariaDB server
 sudo systemctl start mariadb
+
+# Optional: Enable autostart
+sudo systemctl enable mariadb
 ```
 
 ### Setting up the DB

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ CREATE DATABASE campus_backend; -- Create a new DB for the backend
 
 CREATE USER 'gorm'@'localhost' IDENTIFIED BY 'gorm'; -- Create a new user called `gorm`.
 GRANT ALL PRIVILEGES ON campus_backend.* TO 'gorm'@'localhost'; -- Garant our `gorm` user access to the `campus_backend` DB.
+ALTER USER 'gorm'@'localhost' IDENTIFIED BY 'GORM_USER_PASSWORD'; -- Set a password for the `gorm` user.
+FLUSH PRIVILEGES;
 ```
 
 ### Starting
@@ -59,7 +61,7 @@ To start the server there are environment variables, as well as command line opt
 
 ```bash
 cd  server
-export DB_DSN="Your gorm DB connection string for example: gorm@tcp(localhost:3306)/campus_backend"
+export DB_DSN="Your gorm DB connection string for example: gorm:GORM_USER_PASSWORD@tcp(localhost:3306)/campus_backend"
 go run ./main.go [-MensaCron 0]
 ```
 

--- a/server/main.go
+++ b/server/main.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"gorm.io/driver/mysql"
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
 
@@ -43,13 +42,13 @@ func main() {
 	// Connect to DB
 	var conn gorm.Dialector
 	shouldAutoMigrate := false
-	if dbHost := os.Getenv("DB_DSN"); dbHost != "" {
+	dbHost := os.Getenv("DB_DSN")
+	if dbHost != "" {
 		log.Info("Connecting to dsn")
 		conn = mysql.Open(dbHost)
 	} else {
-		log.Info("Switching to test.db")
-		conn = sqlite.Open("test.db")
-		shouldAutoMigrate = true
+		log.Error("Failed to start! The 'DB_DSN' environment variable is not defined. Take a look at the README.md for more details.")
+		os.Exit(-1)
 	}
 
 	environment := "development"


### PR DESCRIPTION
This PR removes to possibility of connecting to a SQLite DB since all DB commands are incompatible with it anyway.
So from now on the only option is to use a MySQL connection.

I also added proper docs for setting up the backend for local development.

Solves: https://github.com/TUM-Dev/Campus-Backend/issues/111