### PR TITLE
chore:news testing

### DIFF
--- a/server/api/CampusService.pb.go
+++ b/server/api/CampusService.pb.go
@@ -999,7 +999,7 @@ func (x *Room) GetName() string {
 	return ""
 }
 
-type NewsSourceArray struct {
+type NewsSourceReply struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
@@ -1007,8 +1007,8 @@ type NewsSourceArray struct {
 	Sources []*NewsSource `protobuf:"bytes,1,rep,name=sources,proto3" json:"sources,omitempty"`
 }
 
-func (x *NewsSourceArray) Reset() {
-	*x = NewsSourceArray{}
+func (x *NewsSourceReply) Reset() {
+	*x = NewsSourceReply{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_CampusService_proto_msgTypes[17]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1016,13 +1016,13 @@ func (x *NewsSourceArray) Reset() {
 	}
 }
 
-func (x *NewsSourceArray) String() string {
+func (x *NewsSourceReply) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*NewsSourceArray) ProtoMessage() {}
+func (*NewsSourceReply) ProtoMessage() {}
 
-func (x *NewsSourceArray) ProtoReflect() protoreflect.Message {
+func (x *NewsSourceReply) ProtoReflect() protoreflect.Message {
 	mi := &file_CampusService_proto_msgTypes[17]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1034,12 +1034,12 @@ func (x *NewsSourceArray) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use NewsSourceArray.ProtoReflect.Descriptor instead.
-func (*NewsSourceArray) Descriptor() ([]byte, []int) {
+// Deprecated: Use NewsSourceReply.ProtoReflect.Descriptor instead.
+func (*NewsSourceReply) Descriptor() ([]byte, []int) {
 	return file_CampusService_proto_rawDescGZIP(), []int{17}
 }
 
-func (x *NewsSourceArray) GetSources() []*NewsSource {
+func (x *NewsSourceReply) GetSources() []*NewsSource {
 	if x != nil {
 		return x.Sources
 	}
@@ -4857,7 +4857,7 @@ var file_CampusService_proto_rawDesc = []byte{
 	0x6d, 0x70, 0x75, 0x73, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x63, 0x61, 0x6d, 0x70,
 	0x75, 0x73, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x09, 0x20, 0x01, 0x28, 0x09,
 	0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x22, 0x3c, 0x0a, 0x0f, 0x4e, 0x65, 0x77, 0x73, 0x53, 0x6f,
-	0x75, 0x72, 0x63, 0x65, 0x41, 0x72, 0x72, 0x61, 0x79, 0x12, 0x29, 0x0a, 0x07, 0x73, 0x6f, 0x75,
+	0x75, 0x72, 0x63, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x12, 0x29, 0x0a, 0x07, 0x73, 0x6f, 0x75,
 	0x72, 0x63, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x0f, 0x2e, 0x61, 0x70, 0x69,
 	0x2e, 0x4e, 0x65, 0x77, 0x73, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x52, 0x07, 0x73, 0x6f, 0x75,
 	0x72, 0x63, 0x65, 0x73, 0x22, 0x4e, 0x0a, 0x0a, 0x4e, 0x65, 0x77, 0x73, 0x53, 0x6f, 0x75, 0x72,
@@ -5273,7 +5273,7 @@ var file_CampusService_proto_rawDesc = []byte{
 	0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x73, 0x12, 0x16, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
 	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x1a,
 	0x14, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x4e, 0x65, 0x77, 0x73, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65,
-	0x41, 0x72, 0x72, 0x61, 0x79, 0x22, 0x1e, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x18, 0x62, 0x07, 0x73,
+	0x52, 0x65, 0x70, 0x6c, 0x79, 0x22, 0x1e, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x18, 0x62, 0x07, 0x73,
 	0x6f, 0x75, 0x72, 0x63, 0x65, 0x73, 0x12, 0x0d, 0x2f, 0x6e, 0x65, 0x77, 0x73, 0x2f, 0x73, 0x6f,
 	0x75, 0x72, 0x63, 0x65, 0x73, 0x12, 0x68, 0x0a, 0x0b, 0x53, 0x65, 0x61, 0x72, 0x63, 0x68, 0x52,
 	0x6f, 0x6f, 0x6d, 0x73, 0x12, 0x17, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x53, 0x65, 0x61, 0x72, 0x63,
@@ -5549,7 +5549,7 @@ var file_CampusService_proto_goTypes = []interface{}{
 	(*SearchRoomsRequest)(nil),                     // 15: api.SearchRoomsRequest
 	(*SearchRoomsReply)(nil),                       // 16: api.SearchRoomsReply
 	(*Room)(nil),                                   // 17: api.Room
-	(*NewsSourceArray)(nil),                        // 18: api.NewsSourceArray
+	(*NewsSourceReply)(nil),                        // 18: api.NewsSourceReply
 	(*NewsSource)(nil),                             // 19: api.NewsSource
 	(*GetTopNewsReply)(nil),                        // 20: api.GetTopNewsReply
 	(*CafeteriaRatingRequest)(nil),                 // 21: api.CafeteriaRatingRequest
@@ -5617,7 +5617,7 @@ var file_CampusService_proto_depIdxs = []int32{
 	72, // 5: api.GetRoomMapsReply.maps:type_name -> api.GetRoomMapsReply.Map
 	73, // 6: api.GetLocationsReply.locations:type_name -> api.GetLocationsReply.Location
 	17, // 7: api.SearchRoomsReply.rooms:type_name -> api.Room
-	19, // 8: api.NewsSourceArray.sources:type_name -> api.NewsSource
+	19, // 8: api.NewsSourceReply.sources:type_name -> api.NewsSource
 	74, // 9: api.GetTopNewsReply.created:type_name -> google.protobuf.Timestamp
 	74, // 10: api.GetTopNewsReply.from:type_name -> google.protobuf.Timestamp
 	74, // 11: api.GetTopNewsReply.to:type_name -> google.protobuf.Timestamp
@@ -5688,7 +5688,7 @@ var file_CampusService_proto_depIdxs = []int32{
 	1,  // 76: api.Campus.RegisterDevice:input_type -> api.RegisterDeviceRequest
 	3,  // 77: api.Campus.RemoveDevice:input_type -> api.RemoveDeviceRequest
 	20, // 78: api.Campus.GetTopNews:output_type -> api.GetTopNewsReply
-	18, // 79: api.Campus.GetNewsSources:output_type -> api.NewsSourceArray
+	18, // 79: api.Campus.GetNewsSources:output_type -> api.NewsSourceReply
 	16, // 80: api.Campus.SearchRooms:output_type -> api.SearchRoomsReply
 	14, // 81: api.Campus.GetLocations:output_type -> api.GetLocationsReply
 	12, // 82: api.Campus.GetRoomMaps:output_type -> api.GetRoomMapsReply
@@ -5941,7 +5941,7 @@ func file_CampusService_proto_init() {
 			}
 		}
 		file_CampusService_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*NewsSourceArray); i {
+			switch v := v.(*NewsSourceReply); i {
 			case 0:
 				return &v.state
 			case 1:

--- a/server/api/CampusService.pb.gw.go
+++ b/server/api/CampusService.pb.gw.go
@@ -3053,7 +3053,7 @@ type response_Campus_GetNewsSources_0 struct {
 }
 
 func (m response_Campus_GetNewsSources_0) XXX_ResponseBody() interface{} {
-	response := m.Message.(*NewsSourceArray)
+	response := m.Message.(*NewsSourceReply)
 	return response.Sources
 }
 

--- a/server/api/CampusService.proto
+++ b/server/api/CampusService.proto
@@ -19,7 +19,7 @@ service Campus {
     };
   }
 
-  rpc GetNewsSources (google.protobuf.Empty) returns (NewsSourceArray) {
+  rpc GetNewsSources (google.protobuf.Empty) returns (NewsSourceReply) {
     option (google.api.http) = {
       get: "/news/sources",
       response_body: "sources"
@@ -376,7 +376,7 @@ message Room {
   string name = 9;
 }
 
-message NewsSourceArray {
+message NewsSourceReply {
   repeated NewsSource sources = 1;
 }
 

--- a/server/api/CampusService_grpc.pb.go
+++ b/server/api/CampusService_grpc.pb.go
@@ -63,7 +63,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type CampusClient interface {
 	GetTopNews(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*GetTopNewsReply, error)
-	GetNewsSources(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*NewsSourceArray, error)
+	GetNewsSources(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*NewsSourceReply, error)
 	SearchRooms(ctx context.Context, in *SearchRoomsRequest, opts ...grpc.CallOption) (*SearchRoomsReply, error)
 	// a location is a campus location/building, e.g. "Garching Forschungszentrum"
 	GetLocations(ctx context.Context, in *GetLocationsRequest, opts ...grpc.CallOption) (*GetLocationsReply, error)
@@ -122,8 +122,8 @@ func (c *campusClient) GetTopNews(ctx context.Context, in *emptypb.Empty, opts .
 	return out, nil
 }
 
-func (c *campusClient) GetNewsSources(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*NewsSourceArray, error) {
-	out := new(NewsSourceArray)
+func (c *campusClient) GetNewsSources(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*NewsSourceReply, error) {
+	out := new(NewsSourceReply)
 	err := c.cc.Invoke(ctx, Campus_GetNewsSources_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -442,7 +442,7 @@ func (c *campusClient) RemoveDevice(ctx context.Context, in *RemoveDeviceRequest
 // for forward compatibility
 type CampusServer interface {
 	GetTopNews(context.Context, *emptypb.Empty) (*GetTopNewsReply, error)
-	GetNewsSources(context.Context, *emptypb.Empty) (*NewsSourceArray, error)
+	GetNewsSources(context.Context, *emptypb.Empty) (*NewsSourceReply, error)
 	SearchRooms(context.Context, *SearchRoomsRequest) (*SearchRoomsReply, error)
 	// a location is a campus location/building, e.g. "Garching Forschungszentrum"
 	GetLocations(context.Context, *GetLocationsRequest) (*GetLocationsReply, error)
@@ -492,7 +492,7 @@ type UnimplementedCampusServer struct {
 func (UnimplementedCampusServer) GetTopNews(context.Context, *emptypb.Empty) (*GetTopNewsReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetTopNews not implemented")
 }
-func (UnimplementedCampusServer) GetNewsSources(context.Context, *emptypb.Empty) (*NewsSourceArray, error) {
+func (UnimplementedCampusServer) GetNewsSources(context.Context, *emptypb.Empty) (*NewsSourceReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetNewsSources not implemented")
 }
 func (UnimplementedCampusServer) SearchRooms(context.Context, *SearchRoomsRequest) (*SearchRoomsReply, error) {

--- a/server/api/gen/openapiv2/CampusService.swagger.json
+++ b/server/api/gen/openapiv2/CampusService.swagger.json
@@ -1925,7 +1925,7 @@
         }
       }
     },
-    "apiNewsSourceArray": {
+    "apiNewsSourceReply": {
       "type": "object",
       "properties": {
         "sources": {

--- a/server/backend/device.go
+++ b/server/backend/device.go
@@ -22,6 +22,15 @@ type deviceBuffer struct {
 	interval time.Duration             // flush interval
 }
 
+func newDeviceBuffer() *deviceBuffer {
+	return &deviceBuffer{
+		lock:     sync.Mutex{},
+		devices:  make(map[string]*model.Devices),
+		interval: time.Minute,
+	}
+
+}
+
 func (s *CampusServer) RunDeviceFlusher() error {
 	for {
 		time.Sleep(s.deviceBuf.interval)

--- a/server/backend/news.go
+++ b/server/backend/news.go
@@ -1,0 +1,61 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	pb "github.com/TUM-Dev/Campus-Backend/server/api"
+	"github.com/TUM-Dev/Campus-Backend/server/model"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
+)
+
+func (s *CampusServer) GetNewsSources(ctx context.Context, _ *emptypb.Empty) (newsSources *pb.NewsSourceReply, err error) {
+	if err = s.checkDevice(ctx); err != nil {
+		return
+	}
+
+	var sources []model.NewsSource
+	if err := s.db.Joins("Files").Find(&sources).Error; err != nil {
+		log.WithError(err).Error("could not find newsSources")
+		return nil, status.Error(codes.Internal, "could not GetNewsSources")
+	}
+
+	var resp []*pb.NewsSource
+	for _, source := range sources {
+		log.WithField("title", source.Title).Trace("sending news source")
+		resp = append(resp, &pb.NewsSource{
+			Source: fmt.Sprintf("%d", source.Source),
+			Title:  source.Title,
+			Icon:   source.Files.URL.String,
+		})
+	}
+	return &pb.NewsSourceReply{Sources: resp}, nil
+}
+
+func (s *CampusServer) GetTopNews(ctx context.Context, _ *emptypb.Empty) (*pb.GetTopNewsReply, error) {
+	if err := s.checkDevice(ctx); err != nil {
+		return nil, err
+	}
+
+	var res *model.NewsAlert
+	err := s.db.Joins("Files").Where("NOW() between `from` and `to`").First(&res).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, status.Error(codes.NotFound, "no currenty active top news")
+	} else if err != nil {
+		log.WithError(err).Error("could not GetTopNews")
+		return nil, status.Error(codes.Internal, "could not GetTopNews")
+	}
+
+	return &pb.GetTopNewsReply{
+		ImageUrl: res.Files.URL.String,
+		Link:     res.Link.String,
+		Created:  timestamppb.New(res.Created),
+		From:     timestamppb.New(res.From),
+		To:       timestamppb.New(res.To),
+	}, nil
+}

--- a/server/backend/news_test.go
+++ b/server/backend/news_test.go
@@ -1,0 +1,186 @@
+package backend
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/DATA-DOG/go-sqlmock"
+	pb "github.com/TUM-Dev/Campus-Backend/server/api"
+	"github.com/TUM-Dev/Campus-Backend/server/model"
+	"github.com/guregu/null"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"regexp"
+	"testing"
+	"time"
+)
+
+type NewsSuite struct {
+	suite.Suite
+	DB        *gorm.DB
+	mock      sqlmock.Sqlmock
+	deviceBuf *deviceBuffer
+}
+
+func (s *NewsSuite) SetupSuite() {
+	var (
+		db  *sql.DB
+		err error
+	)
+
+	db, s.mock, err = sqlmock.New()
+	require.NoError(s.T(), err)
+
+	dialector := mysql.New(mysql.Config{
+		Conn:       db,
+		DriverName: "mysql",
+	})
+	s.mock.ExpectQuery("SELECT VERSION()").
+		WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow("10.11.4-MariaDB"))
+	s.DB, err = gorm.Open(dialector, &gorm.Config{})
+	require.NoError(s.T(), err)
+
+	s.deviceBuf = newDeviceBuffer()
+}
+
+func source1() *model.NewsSource {
+	return &model.NewsSource{
+		Source:  1,
+		Title:   "Amazing News 1",
+		URL:     null.String{NullString: sql.NullString{String: "https://example.com/amazing1", Valid: true}},
+		FilesID: 2,
+		Files: model.Files{
+			File:       2,
+			Name:       "src_2.png",
+			Path:       "news/sources",
+			Downloads:  1,
+			URL:        sql.NullString{Valid: false},
+			Downloaded: sql.NullBool{Bool: true, Valid: true},
+		},
+		Hook: null.String{NullString: sql.NullString{String: "", Valid: true}},
+	}
+}
+
+func source2() *model.NewsSource {
+	return &model.NewsSource{
+		Source:  2,
+		Title:   "Amazing News 2",
+		URL:     null.String{NullString: sql.NullString{String: "https://example.com/amazing2", Valid: true}},
+		FilesID: 2,
+		Files: model.Files{
+			File:       2,
+			Name:       "src_2.png",
+			Path:       "news/sources",
+			Downloads:  1,
+			URL:        sql.NullString{Valid: false},
+			Downloaded: sql.NullBool{Bool: true, Valid: true},
+		},
+		Hook: null.String{NullString: sql.NullString{String: "hook", Valid: true}},
+	}
+}
+
+const ExpectedGetSourceQuery = "SELECT `newsSource`.`source`,`newsSource`.`title`,`newsSource`.`url`,`newsSource`.`icon`,`newsSource`.`hook`,`Files`.`file` AS `Files__file`,`Files`.`name` AS `Files__name`,`Files`.`path` AS `Files__path`,`Files`.`downloads` AS `Files__downloads`,`Files`.`url` AS `Files__url`,`Files`.`downloaded` AS `Files__downloaded` FROM `newsSource` LEFT JOIN `files` `Files` ON `newsSource`.`icon` = `Files`.`file`"
+
+func (s *NewsSuite) Test_GetNewsSourcesMultiple() {
+	s.mock.ExpectQuery(regexp.QuoteMeta(ExpectedGetSourceQuery)).
+		WillReturnRows(sqlmock.NewRows([]string{"source", "title", "url", "icon", "hook", "Files__file", "Files__name", "Files__path", "Files__downloads", "Files__url", "Files__downloaded"}).
+			AddRow(source1().Source, source1().Title, source1().URL, source1().FilesID, source1().Hook, source1().Files.File, source1().Files.Name, source1().Files.Path, source1().Files.Downloads, source1().Files.URL, source1().Files.Downloaded).
+			AddRow(source2().Source, source2().Title, source2().URL, source2().FilesID, source2().Hook, source2().Files.File, source2().Files.Name, source2().Files.Path, source2().Files.Downloads, source2().Files.URL, source2().Files.Downloaded))
+
+	meta := metadata.MD{}
+	server := CampusServer{db: s.DB, deviceBuf: s.deviceBuf}
+	response, err := server.GetNewsSources(metadata.NewIncomingContext(context.Background(), meta), nil)
+	require.NoError(s.T(), err)
+	expectedResp := &pb.NewsSourceReply{
+		Sources: []*pb.NewsSource{
+			{Source: fmt.Sprintf("%d", source1().Source), Title: source1().Title, Icon: source1().Files.URL.String},
+			{Source: fmt.Sprintf("%d", source2().Source), Title: source2().Title, Icon: source2().Files.URL.String},
+		},
+	}
+	require.Equal(s.T(), expectedResp, response)
+}
+
+func (s *NewsSuite) Test_GetNewsSourcesNone() {
+	s.mock.ExpectQuery(regexp.QuoteMeta(ExpectedGetSourceQuery)).
+		WillReturnRows(sqlmock.NewRows([]string{"source", "title", "url", "icon", "hook", "Files__file", "Files__name", "Files__path", "Files__downloads", "Files__url", "Files__downloaded"}))
+
+	meta := metadata.MD{}
+	server := CampusServer{db: s.DB, deviceBuf: s.deviceBuf}
+	response, err := server.GetNewsSources(metadata.NewIncomingContext(context.Background(), meta), nil)
+	require.NoError(s.T(), err)
+	expectedResp := &pb.NewsSourceReply{
+		Sources: []*pb.NewsSource(nil),
+	}
+	require.Equal(s.T(), expectedResp, response)
+}
+
+const ExpectedGetTopNewsQuery = "SELECT `news_alert`.`news_alert`,`news_alert`.`file`,`news_alert`.`name`,`news_alert`.`link`,`news_alert`.`created`,`news_alert`.`from`,`news_alert`.`to`,`Files`.`file` AS `Files__file`,`Files`.`name` AS `Files__name`,`Files`.`path` AS `Files__path`,`Files`.`downloads` AS `Files__downloads`,`Files`.`url` AS `Files__url`,`Files`.`downloaded` AS `Files__downloaded` FROM `news_alert` LEFT JOIN `files` `Files` ON `news_alert`.`file` = `Files`.`file` WHERE NOW() between `from` and `to` ORDER BY `news_alert`.`news_alert` LIMIT 1"
+
+func (s *NewsSuite) Test_GetTopNewsOne() {
+	expectedAlert := model.NewsAlert{
+		NewsAlert: 1,
+		FilesID:   3001,
+		Files: model.Files{
+			File:       3001,
+			Name:       "Tournament_app_02-02.png",
+			Path:       "newsalerts/",
+			Downloads:  0,
+			URL:        sql.NullString{Valid: false},
+			Downloaded: sql.NullBool{Bool: true, Valid: true},
+		},
+		Name:    null.String{NullString: sql.NullString{String: "Exzellenzuniversität", Valid: true}},
+		Link:    null.String{NullString: sql.NullString{String: "https://tum.de", Valid: true}},
+		Created: time.Time.Add(time.Now(), time.Hour*-4),
+		From:    time.Time.Add(time.Now(), time.Hour*-2),
+		To:      time.Time.Add(time.Now(), time.Hour*2),
+	}
+	s.mock.ExpectQuery(regexp.QuoteMeta(ExpectedGetTopNewsQuery)).
+		WillReturnRows(sqlmock.NewRows([]string{"news_alert", "file", "name", "link", "created", "from", "to", "Files__file", "Files__name", "Files__path", "Files__downloads", "Files__url", "Files__downloaded"}).
+			AddRow(expectedAlert.NewsAlert, expectedAlert.FilesID, expectedAlert.Name, expectedAlert.Link, expectedAlert.Created, expectedAlert.From, expectedAlert.To, expectedAlert.Files.File, expectedAlert.Files.Name, expectedAlert.Files.Path, expectedAlert.Files.Downloads, expectedAlert.Files.URL, expectedAlert.Files.Downloaded))
+
+	meta := metadata.MD{}
+	server := CampusServer{db: s.DB, deviceBuf: s.deviceBuf}
+	response, err := server.GetTopNews(metadata.NewIncomingContext(context.Background(), meta), nil)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), &pb.GetTopNewsReply{
+		ImageUrl: expectedAlert.Files.URL.String,
+		Link:     expectedAlert.Link.String,
+		Created:  timestamppb.New(expectedAlert.Created),
+		From:     timestamppb.New(expectedAlert.From),
+		To:       timestamppb.New(expectedAlert.To),
+	}, response)
+}
+func (s *NewsSuite) Test_GetTopNewsNone() {
+	s.mock.ExpectQuery(regexp.QuoteMeta(ExpectedGetTopNewsQuery)).WillReturnError(gorm.ErrRecordNotFound)
+
+	meta := metadata.MD{}
+	server := CampusServer{db: s.DB, deviceBuf: s.deviceBuf}
+	response, err := server.GetTopNews(metadata.NewIncomingContext(context.Background(), meta), nil)
+	require.Equal(s.T(), status.Error(codes.NotFound, "no currenty active top news"), err)
+	require.Nil(s.T(), response)
+}
+func (s *NewsSuite) Test_GetTopNewsError() {
+	s.mock.ExpectQuery(regexp.QuoteMeta(ExpectedGetTopNewsQuery)).WillReturnError(gorm.ErrInvalidDB)
+
+	meta := metadata.MD{}
+	server := CampusServer{db: s.DB, deviceBuf: s.deviceBuf}
+	response, err := server.GetTopNews(metadata.NewIncomingContext(context.Background(), meta), nil)
+	require.Equal(s.T(), status.Error(codes.Internal, "could not GetTopNews"), err)
+	require.Nil(s.T(), response)
+}
+
+func (s *NewsSuite) AfterTest(_, _ string) {
+	require.NoError(s.T(), s.mock.ExpectationsWereMet())
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestExampleTestSuite(t *testing.T) {
+	suite.Run(t, new(NewsSuite))
+}

--- a/server/backend/rpcserver.go
+++ b/server/backend/rpcserver.go
@@ -13,8 +13,6 @@ import (
 	"google.golang.org/grpc/status"
 	"gorm.io/gorm"
 	"net"
-	"sync"
-	"time"
 )
 
 func (s *CampusServer) GRPCServe(l net.Listener) error {
@@ -41,12 +39,8 @@ func New(db *gorm.DB) *CampusServer {
 	initTagRatingOptions(db)
 
 	return &CampusServer{
-		db: db,
-		deviceBuf: &deviceBuffer{
-			lock:     sync.Mutex{},
-			devices:  make(map[string]*model.Devices),
-			interval: time.Minute,
-		},
+		db:                      db,
+		deviceBuf:               newDeviceBuffer(),
 		iOSNotificationsService: NewIOSNotificationsService(),
 	}
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -3,6 +3,7 @@ module github.com/TUM-Dev/Campus-Backend/server
 go 1.21
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/disintegration/imaging v1.6.2
 	github.com/gabriel-vasile/mimetype v1.4.2
 	github.com/getsentry/sentry-go v0.23.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -42,6 +42,8 @@ github.com/BurntSushi/toml v1.2.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
 github.com/CloudyKit/jet/v6 v6.1.0/go.mod h1:d3ypHeIRNo2+XyqnGA8s+aphtcVpjP5hPwP/Lzo7Ro4=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0gta/U=

--- a/server/model/news_alert.go
+++ b/server/model/news_alert.go
@@ -17,20 +17,14 @@ var (
 
 // NewsAlert struct is a row record of the news_alert table in the tca database
 type NewsAlert struct {
-	//[ 0] news_alert                                     int                  null: false  primary: true   isArray: false  auto: true   col: int             len: -1      default: []
-	NewsAlert int32 `gorm:"primary_key;AUTO_INCREMENT;column:news_alert;type:int;" json:"news_alert"`
-	//[ 1] file                                           int                  null: true   primary: false  isArray: false  auto: false  col: int             len: -1      default: []
-	File null.Int `gorm:"column:file;type:int;" json:"file"`
-	//[ 2] name                                           varchar(100)         null: true   primary: false  isArray: false  auto: false  col: varchar         len: 100     default: []
-	Name null.String `gorm:"column:name;type:varchar(100);" json:"name"`
-	//[ 3] link                                           text(65535)          null: true   primary: false  isArray: false  auto: false  col: text            len: 65535   default: []
-	Link null.String `gorm:"column:link;type:text;size:65535;" json:"link"`
-	//[ 4] created                                        timestamp            null: false  primary: false  isArray: false  auto: false  col: timestamp       len: -1      default: [CURRENT_TIMESTAMP]
-	Created time.Time `gorm:"column:created;type:timestamp;default:CURRENT_TIMESTAMP;" json:"created"`
-	//[ 5] from                                           datetime             null: false  primary: false  isArray: false  auto: false  col: datetime        len: -1      default: [CURRENT_TIMESTAMP]
-	From time.Time `gorm:"column:from;type:datetime;default:CURRENT_TIMESTAMP;" json:"from"`
-	//[ 6] to                                             datetime             null: false  primary: false  isArray: false  auto: false  col: datetime        len: -1      default: [CURRENT_TIMESTAMP]
-	To time.Time `gorm:"column:to;type:datetime;default:CURRENT_TIMESTAMP;" json:"to"`
+	NewsAlert int32       `gorm:"primary_key;AUTO_INCREMENT;column:news_alert;type:int;" json:"news_alert"`
+	FilesID   int32       `gorm:"column:file;not null"`
+	Files     Files       `gorm:"foreignKey:FilesID;references:file;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	Name      null.String `gorm:"column:name;type:varchar(100);" json:"name"`
+	Link      null.String `gorm:"column:link;type:text;size:65535;" json:"link"`
+	Created   time.Time   `gorm:"column:created;type:timestamp;default:CURRENT_TIMESTAMP;" json:"created"`
+	From      time.Time   `gorm:"column:from;type:datetime;default:CURRENT_TIMESTAMP;" json:"from"`
+	To        time.Time   `gorm:"column:to;type:datetime;default:CURRENT_TIMESTAMP;" json:"to"`
 }
 
 // TableName sets the insert table name for this struct type

--- a/server/model/news_source.go
+++ b/server/model/news_source.go
@@ -17,16 +17,12 @@ var (
 
 // NewsSource struct is a row record of the newsSource table in the tca database
 type NewsSource struct {
-	//[ 0] source                                         int                  null: false  primary: true   isArray: false  auto: true   col: int             len: -1      default: []
-	Source int32 `gorm:"primary_key;AUTO_INCREMENT;column:source;type:int;" json:"source"`
-	//[ 1] title                                          text(16777215)       null: false  primary: false  isArray: false  auto: false  col: text            len: 16777215 default: []
-	Title string `gorm:"column:title;type:text;size:16777215;" json:"title"`
-	//[ 2] url                                            text(16777215)       null: true   primary: false  isArray: false  auto: false  col: text            len: 16777215 default: []
-	URL null.String `gorm:"column:url;type:text;size:16777215;" json:"url"`
-	//[ 3] icon                                           int                  null: true   primary: false  isArray: false  auto: false  col: int             len: -1      default: []
-	Icon null.Int `gorm:"column:icon;type:int;" json:"icon"`
-	//[ 4] hook                                           char(12)             null: true   primary: false  isArray: false  auto: false  col: char            len: 12      default: []
-	Hook null.String `gorm:"column:hook;type:char;size:12;" json:"hook"`
+	Source  int32       `gorm:"primary_key;AUTO_INCREMENT;column:source;type:int;"`
+	Title   string      `gorm:"column:title;type:text;size:16777215;"`
+	URL     null.String `gorm:"column:url;type:text;size:16777215;"`
+	FilesID int32       `gorm:"column:icon;not null"`
+	Files   Files       `gorm:"foreignKey:FilesID;references:file;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	Hook    null.String `gorm:"column:hook;type:char;size:12;"`
 }
 
 // TableName sets the insert table name for this struct type

--- a/server/swagger/swagger.json
+++ b/server/swagger/swagger.json
@@ -1925,7 +1925,7 @@
         }
       }
     },
-    "apiNewsSourceArray": {
+    "apiNewsSourceReply": {
       "type": "object",
       "properties": {
         "sources": {


### PR DESCRIPTION
This PR adds tests to the news APIs and fixes the following defects:
- `GetNewsSources` previously did not join with other tables and instead requested more information via additional queries
- `GetNewsSources` previously did join with a non-existing table (`Company`) resulting in a broken query
- `GetNewsSources` previously did not fill out all fields returned correctly
- `NewsSourceArray` was not named `NewsSourceReply` like the other responses