### PR TITLE
bug:file download

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -3,7 +3,7 @@ module github.com/TUM-Dev/Campus-Backend/client
 go 1.21
 
 require (
-	github.com/TUM-Dev/Campus-Backend/server v0.0.0-20230920223017-73df1e4061c8
+	github.com/TUM-Dev/Campus-Backend/server v0.0.0-20230921201035-301a0c7bab98
 	github.com/sirupsen/logrus v1.9.3
 	google.golang.org/grpc v1.58.1
 )

--- a/client/go.sum
+++ b/client/go.sum
@@ -1,5 +1,5 @@
-github.com/TUM-Dev/Campus-Backend/server v0.0.0-20230920223017-73df1e4061c8 h1:FYhgX9DA9JvEyP06VX/Ot/8Oav9fS8hwHhGOyLfvX6E=
-github.com/TUM-Dev/Campus-Backend/server v0.0.0-20230920223017-73df1e4061c8/go.mod h1:fjoLL3rbdY6wTRJIksekT2p3OUp5ocFfXjB/avV/TVI=
+github.com/TUM-Dev/Campus-Backend/server v0.0.0-20230921201035-301a0c7bab98 h1:cifzCP3eUZgN+iqfhfGPTL1JFz4g/qjBNpwhcjlKOWk=
+github.com/TUM-Dev/Campus-Backend/server v0.0.0-20230921201035-301a0c7bab98/go.mod h1:fjoLL3rbdY6wTRJIksekT2p3OUp5ocFfXjB/avV/TVI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/server/backend/cron/fileDownload.go
+++ b/server/backend/cron/fileDownload.go
@@ -2,11 +2,12 @@ package cron
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"image"
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/TUM-Dev/Campus-Backend/server/model"
@@ -19,13 +20,24 @@ import (
 // fileDownloadCron Downloads all files that are not marked as finished in the database.
 func (c *CronService) fileDownloadCron() error {
 	var files []model.Files
-	err := c.db.Find(&files, "downloaded = 0").Scan(&files).Error
-	if err != nil && err != gorm.ErrRecordNotFound {
+	err := c.db.Find(&files, "downloaded = 0").Error
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		log.WithError(err).Error("Could not get files from database")
 		return err
 	}
-	for i := range files {
-		if files[i].URL.Valid {
-			c.downloadFile(files[i])
+	for _, file := range files {
+		if !file.URL.Valid {
+			log.WithField("fileId", file.File).Info("skipping file without url")
+			continue
+		}
+		log.WithField("url", file.URL.String).Info("downloading file")
+		if err := downloadFile(&file); err != nil {
+			log.WithError(err).WithField("url", file.URL.String).Warn("Could not download file")
+			continue
+		}
+		if err = c.db.Model(&model.Files{URL: file.URL}).Update("downloaded", true).Error; err != nil {
+			log.WithError(err).Error("Could not set image to downloaded.")
+			continue
 		}
 	}
 	return nil
@@ -34,51 +46,40 @@ func (c *CronService) fileDownloadCron() error {
 // downloadFile Downloads a file, marks it downloaded and resizes it if it's an image.
 // url: download url of the file
 // name: target name of the file
-func (c *CronService) downloadFile(file model.Files) {
-	if !file.URL.Valid {
-		log.WithField("fileId", file.File).Info("skipping file without url")
-	}
-	url := file.URL.String
-	log.WithField("url", url).Info("downloading file")
-	resp, err := http.Get(url)
+func downloadFile(file *model.Files) error {
+	resp, err := http.Get(file.URL.String)
 	if err != nil {
-		log.WithError(err).WithField("url", url).Warn("Could not download image")
-		return
+		log.WithError(err).WithField("url", file.URL.String).Warn("Could not download image")
+		return err
 	}
 	// read body here because we can't exhaust the io.reader twice
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.WithError(err).Warn("Unable to read http body")
-		return
+		return err
 	}
 
-	// resize if file is image
-	mime := mimetype.Detect(body)
-	if strings.HasPrefix(mime.String(), "image/") {
+	// in our case resolves to /Storage/news/newspread/1234abc.jpg
+	dstPath := path.Join(StorageDir, file.Path, file.Name)
+	if strings.HasPrefix(mimetype.Detect(body).String(), "image/") {
+		// save with resizing
 		downloadedImg, _, err := image.Decode(bytes.NewReader(body))
 		if err != nil {
-			log.WithError(err).WithField("url", url).Warn("Couldn't decode source image")
-			return
+			log.WithError(err).WithField("url", file.URL.String).Warn("Couldn't decode source image")
+			return err
 		}
 
-		// in our case resolves to /Storage/news/newspread/1234abc.jpg
-		dstFileName := fmt.Sprintf("%s%s", file.Path, file.Name)
-		dstImage := imaging.Resize(downloadedImg, 1280, 0, imaging.Lanczos)
-		err = imaging.Save(dstImage, StorageDir+dstFileName, imaging.JPEGQuality(75))
-		if err != nil {
-			log.WithError(err).WithField("url", url).Warn("Could not save image file")
-			return
+		resizedImage := imaging.Resize(downloadedImg, 1280, 0, imaging.Lanczos)
+		if err = imaging.Save(resizedImage, dstPath, imaging.JPEGQuality(75)); err != nil {
+			log.WithError(err).WithField("url", file.URL.String).Warn("Could not save image file")
+			return err
 		}
 	} else {
 		// save without resizing image
-		err = os.WriteFile(fmt.Sprintf("%s%s", file.Path, file.Name), body, 0644)
-		if err != nil {
+		if err := os.WriteFile(dstPath, body, 0644); err != nil {
 			log.WithError(err).Error("Can't save file to disk")
-			return
+			return err
 		}
 	}
-	err = c.db.Model(&model.Files{}).Where("url = ?", url).Update("downloaded", true).Error
-	if err != nil {
-		log.WithError(err).Error("Could not set image to downloaded.")
-	}
+	return nil
 }

--- a/server/backend/cron/fileDownload.go
+++ b/server/backend/cron/fileDownload.go
@@ -59,7 +59,7 @@ func ensureFileDoesNotExist(dstPath string) error {
 	return os.MkdirAll(path.Dir(dstPath), 0755)
 }
 
-// maybeResizeImage resizes the image if it's an image and larger than 1280px
+// maybeResizeImage resizes the image if it's an image to 1280px width keeping the aspect ratio
 func maybeResizeImage(dstPath string) error {
 	mime, err := mimetype.DetectFile(dstPath)
 	if err != nil {

--- a/server/backend/cron/fileDownload.go
+++ b/server/backend/cron/fileDownload.go
@@ -15,7 +15,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// fileDownloadCron Downloads all files that are not marked as finished in the database.
+// fileDownloadCron downloads all files that are not marked as finished in the database
 func (c *CronService) fileDownloadCron() error {
 	return c.db.Transaction(func(tx *gorm.DB) error {
 		var files []model.Files

--- a/server/backend/cron/fileDownload_test.go
+++ b/server/backend/cron/fileDownload_test.go
@@ -43,6 +43,34 @@ func TestMaybeResizeImage(t *testing.T) {
 	})
 }
 
+func TestEnsureFileDoesNotExist(t *testing.T) {
+	tmpFilePath := "test_dir/test_file.txt"
+	defer func() { _ = os.RemoveAll("test_dir") }()
+
+	t.Run("FileDoesNotExist", func(t *testing.T) {
+		require.NoError(t, ensureFileDoesNotExist(tmpFilePath))
+
+		_, dirErr := os.Stat("test_dir")
+		require.NoError(t, dirErr)
+
+		_, fileErr := os.Stat(tmpFilePath)
+		require.True(t, os.IsNotExist(fileErr))
+	})
+
+	t.Run("FileExists", func(t *testing.T) {
+		_, createErr := os.Create(tmpFilePath)
+		require.NoError(t, createErr)
+
+		require.NoError(t, ensureFileDoesNotExist(tmpFilePath))
+
+		_, dirErr := os.Stat("test_dir")
+		require.NoError(t, dirErr)
+
+		_, fileErr := os.Stat(tmpFilePath)
+		require.True(t, os.IsNotExist(fileErr))
+	})
+}
+
 // createDummyImage creates a dummy image file with the specified dimensions
 func createDummyImage(filePath string, width, height int) error {
 	img := image.NewRGBA(image.Rect(0, 0, width, height))

--- a/server/backend/cron/fileDownload_test.go
+++ b/server/backend/cron/fileDownload_test.go
@@ -1,0 +1,63 @@
+package cron
+
+import (
+	"image"
+	"os"
+	"testing"
+
+	"github.com/disintegration/imaging"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaybeResizeImage(t *testing.T) {
+	t.Run("Resize Image", func(t *testing.T) {
+		dstPath := "test_image.jpg"
+		require.NoError(t, createDummyImage(dstPath, 2000, 1000))
+		defer os.Remove(dstPath)
+		require.NoError(t, maybeResizeImage(dstPath))
+		img, err := imaging.Open(dstPath)
+		require.NoError(t, err)
+		require.Equal(t, 1280, img.Bounds().Dx())
+		require.Equal(t, 640, img.Bounds().Dy())
+	})
+	t.Run("Do not Resize smaller Image", func(t *testing.T) {
+		dstPath := "test_image.jpg"
+		require.NoError(t, createDummyImage(dstPath, 1000, 2000))
+		defer os.Remove(dstPath)
+		require.NoError(t, maybeResizeImage(dstPath))
+		img, err := imaging.Open(dstPath)
+		require.NoError(t, err)
+		require.Equal(t, 1280, img.Bounds().Dx())
+		require.Equal(t, 2560, img.Bounds().Dy())
+	})
+
+	t.Run("Skip Non-Image", func(t *testing.T) {
+		nonImageFile := "non_image.txt"
+		content := []byte("Dummy Text")
+		require.NoError(t, createDummyFile(nonImageFile, content))
+		defer os.Remove(nonImageFile)
+		require.NoError(t, maybeResizeImage(nonImageFile))
+		contentAfterExecution, err := os.ReadFile(nonImageFile)
+		require.NoError(t, err)
+		require.Equal(t, content, contentAfterExecution)
+	})
+}
+
+// createDummyImage creates a dummy image file with the specified dimensions
+func createDummyImage(filePath string, width, height int) error {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	return imaging.Save(img, filePath, imaging.JPEGQuality(75))
+}
+
+// createDummyFile creates a dummy non-image file
+func createDummyFile(filePath string, content []byte) error {
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	if _, err := file.Write(content); err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/backend/rpcserver.go
+++ b/server/backend/rpcserver.go
@@ -3,8 +3,9 @@ package backend
 import (
 	"context"
 	"errors"
-	"github.com/TUM-Dev/Campus-Backend/server/env"
 	"net"
+
+	"github.com/TUM-Dev/Campus-Backend/server/env"
 
 	pb "github.com/TUM-Dev/Campus-Backend/server/api/tumdev"
 	"github.com/TUM-Dev/Campus-Backend/server/backend/ios_notifications/ios_apns"


### PR DESCRIPTION
While the concrete bug causing our backend to shut down is not quite apparent, this might shed a bit more information.

Concrete changes:
- updating the `downloads` field
- wrapping the whole thing in a transaction
- Separating functions into testable units and adding tests
- not downloading large files to memory and then dumping them to file (instead download them to file and then read them) ^^
- making sure that already existing and not as finished marked files (i.e. partial downloads) are correctly handled