### PR TITLE
(feat): add cache for movies

### DIFF
--- a/server/backend/movie.go
+++ b/server/backend/movie.go
@@ -44,7 +44,8 @@ func (s *CampusServer) ListMovies(ctx context.Context, req *pb.ListMoviesRequest
 }
 
 func (s *CampusServer) getMovies(ctx context.Context, lastID int32, oldestDateAt time.Time) ([]model.Movie, error) {
-	if movies, ok := s.moviesCache.Get(fmt.Sprintf("%d-%d", lastID, oldestDateAt.Second())); ok {
+	cacheKey := fmt.Sprintf("%d-%d", lastID, oldestDateAt.Second())
+	if movies, ok := s.moviesCache.Get(cacheKey); ok {
 		return movies, nil
 	}
 	var movies []model.Movie
@@ -58,6 +59,6 @@ func (s *CampusServer) getMovies(ctx context.Context, lastID int32, oldestDateAt
 		log.WithError(err).Error("Error while fetching movies from database")
 		return nil, status.Error(codes.Internal, "Error while fetching movies from database")
 	}
-	s.moviesCache.Add(fmt.Sprintf("%d-%d", lastID, oldestDateAt.Second()), movies)
+	s.moviesCache.Add(cacheKey, movies)
 	return movies, nil
 }

--- a/server/backend/movie_test.go
+++ b/server/backend/movie_test.go
@@ -3,14 +3,14 @@ package backend
 import (
 	"context"
 	"database/sql"
-	"github.com/TUM-Dev/Campus-Backend/server/model"
-	"github.com/hashicorp/golang-lru/v2/expirable"
 	"regexp"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	pb "github.com/TUM-Dev/Campus-Backend/server/api/tumdev"
+	"github.com/TUM-Dev/Campus-Backend/server/model"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/server/backend/movie_test.go
+++ b/server/backend/movie_test.go
@@ -3,6 +3,8 @@ package backend
 import (
 	"context"
 	"database/sql"
+	"github.com/TUM-Dev/Campus-Backend/server/model"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"regexp"
 	"testing"
 	"time"
@@ -81,7 +83,7 @@ var (
 const ListMoviesQuery = "SELECT `movies`.`kino`,`movies`.`date`,`movies`.`created`,`movies`.`title`,`movies`.`year`,`movies`.`runtime`,`movies`.`genre`,`movies`.`director`,`movies`.`actors`,`movies`.`rating`,`movies`.`description`,`movies`.`trailer`,`movies`.`cover`,`movies`.`link`,`movies`.`location`,`File`.`file` AS `File__file`,`File`.`name` AS `File__name`,`File`.`path` AS `File__path`,`File`.`downloads` AS `File__downloads`,`File`.`url` AS `File__url`,`File`.`downloaded` AS `File__downloaded` FROM `movies` LEFT JOIN `files` `File` ON `movies`.`cover` = `File`.`file` WHERE kino > ? ORDER BY date ASC"
 
 func (s *MovieSuite) Test_ListMoviesAll() {
-	server := CampusServer{db: s.DB}
+	server := s.getCampusTestServer()
 	s.mock.ExpectQuery(regexp.QuoteMeta(ListMoviesQuery)).
 		WithArgs(-1).
 		WillReturnRows(sqlmock.NewRows([]string{"kino", "date", "created", "title", "year", "runtime", "genre", "director", "actors", "rating", "description", "trailer", "cover", "link", "location", "File__file", "File__name", "File__path", "File__downloads", "File__url", "File__downloaded"}).
@@ -93,7 +95,7 @@ func (s *MovieSuite) Test_ListMoviesAll() {
 }
 
 func (s *MovieSuite) Test_ListMoviesOne() {
-	server := CampusServer{db: s.DB}
+	server := s.getCampusTestServer()
 	s.mock.ExpectQuery(regexp.QuoteMeta(ListMoviesQuery)).
 		WithArgs(1).
 		WillReturnRows(sqlmock.NewRows([]string{"kino", "date", "created", "title", "year", "runtime", "genre", "director", "actors", "rating", "description", "trailer", "cover", "link", "location", "File__file", "File__name", "File__path", "File__downloads", "File__url", "File__downloaded"}).
@@ -104,7 +106,7 @@ func (s *MovieSuite) Test_ListMoviesOne() {
 }
 
 func (s *MovieSuite) Test_ListMoviesNone() {
-	server := CampusServer{db: s.DB}
+	server := s.getCampusTestServer()
 	s.mock.ExpectQuery(regexp.QuoteMeta(ListMoviesQuery)).
 		WithArgs(42).
 		WillReturnRows(sqlmock.NewRows([]string{"kino", "date", "created", "title", "year", "runtime", "genre", "director", "actors", "rating", "description", "trailer", "cover", "link", "location", "File__file", "File__name", "File__path", "File__downloads", "File__url", "File__downloaded"}))
@@ -121,4 +123,11 @@ func (s *MovieSuite) AfterTest(_, _ string) {
 // a normal test function and pass our suite to suite.Run
 func TestMovieSuite(t *testing.T) {
 	suite.Run(t, new(MovieSuite))
+}
+
+func (s *MovieSuite) getCampusTestServer() *CampusServer {
+	return &CampusServer{
+		db:          s.DB,
+		moviesCache: expirable.NewLRU[string, []model.Movie](1024, nil, time.Minute*30),
+	}
 }

--- a/server/backend/rpcserver.go
+++ b/server/backend/rpcserver.go
@@ -18,6 +18,7 @@ type CampusServer struct {
 	deviceBuf                 *deviceBuffer // deviceBuf stores all devices from recent request and flushes them to db
 	newsSourceCache           *expirable.LRU[string, []model.NewsSource]
 	newsCache                 *expirable.LRU[string, []model.News]
+	moviesCache               *expirable.LRU[string, []model.Movie]
 }
 
 // Verify that CampusServer implements the pb.CampusServer interface

--- a/server/backend/rpcserver.go
+++ b/server/backend/rpcserver.go
@@ -32,5 +32,6 @@ func New(db *gorm.DB) *CampusServer {
 		feedbackEmailLastReuestAt: &sync.Map{},
 		newsSourceCache:           expirable.NewLRU[string, []model.NewsSource](1, nil, time.Hour*6),
 		newsCache:                 expirable.NewLRU[string, []model.News](1024, nil, time.Minute*30),
+		moviesCache:               expirable.NewLRU[string, []model.Movie](1024, nil, time.Minute*30),
 	}
 }


### PR DESCRIPTION
The movies table contributes to a majority of our database traffic but is very static. This PR adds a cache to minimize database hits. 