### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete regular expression for hostnames

### DIFF
--- a/server/backend/cron/news.go
+++ b/server/backend/cron/news.go
@@ -196,7 +196,7 @@ func (c *CronService) cleanOldNewsForSource(source int64) error {
 
 // newspreadHook extracts image urls from the body if the feed because such entries are a bit weird
 func (c *CronService) newspreadHook(item *gofeed.Item) {
-	re := regexp.MustCompile(`https://storage.googleapis.com/tum-newspread-de/assets/[a-z\-0-9]+\.jpeg`)
+	re := regexp.MustCompile(`https://storage\.googleapis\.com/tum-newspread-de/assets/[a-z\-0-9]+\.jpeg`)
 	extractedImageSlice := re.FindAllString(item.Content, 1)
 	extractedImageURL := ""
 	if len(extractedImageSlice) != 0 {

--- a/server/backend/cron/news.go
+++ b/server/backend/cron/news.go
@@ -196,11 +196,11 @@ func (c *CronService) cleanOldNewsForSource(source int64) error {
 
 // newspreadHook extracts image urls from the body if the feed because such entries are a bit weird
 func (c *CronService) newspreadHook(item *gofeed.Item) {
-	re := regexp.MustCompile(`https://storage\.googleapis\.com/tum-newspread-de/assets/[a-z\-0-9]+\.jpeg`)
-	extractedImageSlice := re.FindAllString(item.Content, 1)
+	re := regexp.MustCompile(`(?:^|[\s"'(])` + `(https://storage\.googleapis\.com/tum-newspread-de/assets/[a-z\-0-9]+\.jpeg)` + `(?:$|[\s"')])`)
+	extractedImageSlice := re.FindAllStringSubmatch(item.Content, 1)
 	extractedImageURL := ""
-	if len(extractedImageSlice) != 0 {
-		extractedImageURL = extractedImageSlice[0]
+	if len(extractedImageSlice) != 0 && len(extractedImageSlice[0]) > 1 {
+		extractedImageURL = extractedImageSlice[0][1]
 	}
 	item.Enclosures = []*gofeed.Enclosure{{URL: extractedImageURL}}
 	item.Description = ""


### PR DESCRIPTION
Potential fix for [https://github.com/TUM-Dev/Campus-Backend/security/code-scanning/3](https://github.com/TUM-Dev/Campus-Backend/security/code-scanning/3)

To fix this, escape the hostname dots in the regex literal so they are treated as literal periods, not wildcard meta-characters.

Best single fix in `server/backend/cron/news.go`:
- Update `newspreadHook` regex at line 199 from:
  - ``https://storage.googleapis.com/tum-newspread-de/assets/[a-z\-0-9]+\.jpeg``
- To:
  - ``https://storage\.googleapis\.com/tum-newspread-de/assets/[a-z\-0-9]+\.jpeg``

No functional behavior should change except preventing accidental matches of invalid hostnames. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
